### PR TITLE
[Modify] Footer 접근성 보완

### DIFF
--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -245,7 +245,6 @@ class Footer extends LitElement {
               <li>
                 <a
                   href="https://section.blog.naver.com/"
-                  aria-label="네이버블로그"
                   target="_blank"
                   rel="noopener noreferrer"
                   ><img src="/image/blog.webp" alt="naver blog"
@@ -254,7 +253,6 @@ class Footer extends LitElement {
               <li>
                 <a
                   href="https://www.facebook.com/"
-                  aria-label="페이스북"
                   target="_blank"
                   rel="noopener noreferrer"
                   ><img src="/image/facebook.webp" alt="facebook"
@@ -263,7 +261,6 @@ class Footer extends LitElement {
               <li>
                 <a
                   href="https://www.instagram.com/"
-                  aria-label="인스타그램"
                   target="_blank"
                   rel="noopener noreferrer"
                   ><img src="/image/instagram.webp" alt="instagram"
@@ -272,7 +269,6 @@ class Footer extends LitElement {
               <li>
                 <a
                   href="https://post.naver.com/"
-                  aria-label="네이버포스트"
                   target="_blank"
                   rel="noopener noreferrer"
                   ><img src="/image/naverpost.webp" alt="naver post"
@@ -281,7 +277,6 @@ class Footer extends LitElement {
               <li>
                 <a
                   href="https://www.youtube.com/"
-                  aria-label="유튜브"
                   target="_blank"
                   rel="noopener noreferrer"
                   ><img src="/image/youtube.webp" alt="youtube"


### PR DESCRIPTION
- img 태그의 대체텍스트와 겹치던 a태그의 aria-label 삭제

Resolved #64

## PR 유형

- [] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

<!-- PR 작업 내역은 여기에 써주세요. -->
- a 태그의 aria-label 과 img 태그 대체텍스트가 겹치는 이슈로, aria-label 속성 삭제

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->
Resolved #64 